### PR TITLE
[#93688328] Use AUFS storage driver

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for docker_server
 
+- name: Install kernel extras for AUFS support
+  apt: name="{{ item }}" update_cache=yes
+  with_items:
+    - linux-image-extra-{{ ansible_kernel }}
+    - linux-image-extra-virtual
+  notify:
+    - restart docker
+
 - name: Add docker apt key.
   apt_key: keyserver=keyserver.ubuntu.com id=36A1D7869245C8950F966E92D8576A8BA88D21E9
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   with_items: packages
 
 - name: Allow external access
-  lineinfile: dest=/etc/default/docker line='export DOCKER_OPTS="-H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}}"'
+  lineinfile: dest=/etc/default/docker line='export DOCKER_OPTS="-H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}} --storage-driver=aufs"'
   notify:
     - restart docker
 


### PR DESCRIPTION
#### Force AUFS storage driver instead of devicemapper

In order to workaround docker/docker#4036 which prevents us from using
`tsuru-admin platform-add` without multiple attempts:

```
 ---> d26617e2bb8b
Removing intermediate container 3ec79f2117be
Step 8 : RUN mkdir /var/lib/tsuru
 ---> Running in fedd00a99921
error in docker node "http://10.128.1.190:4243": Error getting container fedd00a999218247ec4721d14d5cc446b172c861eb39d58ba1468d408a7b3c19 from driver devicemapper: open /dev/mapper/docker-202:1-524978-fedd00a999218247ec4721d14d5cc446b172c861eb39d58ba1468d408a7b3c19: no such file or directory
Error: Failed to add new platform.
```

On machines which don't have the necessary kernel modules for AUFS support
(such as Ubuntu 14.04 AMIs on AWS which don't have the kernel extras
package) this will cause Docker to fail on start with the error:

```
Shutting down daemon due to errors: error intializing graphdriver: driver not supported
```

This happens too late for upstart to notice, so Ansible won't
register the failure and will attempt to start it again on the next run.
However it will render Docker unusable so we should notice that the right
driver isn't available.
#### Install kernel extra package for AUFS support

So that we're able to use the right storage driver per the previous commit.
This mimics docker/docker@b89d04d and the
issue that references, which explains why we need to install both packages.

It does not require a machine reboot to take effect but it does need to
restart the docker daemon.
