### PR TITLE
Add default socket to listen options

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
   with_items: packages
 
 - name: Allow external access
-  lineinfile: dest=/etc/default/docker line='export DOCKER_OPTS="-H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}} --storage-driver=aufs"'
+  template: src=etc_default_docker dest=/etc/default/docker
   notify:
     - restart docker
 

--- a/templates/etc_default_docker
+++ b/templates/etc_default_docker
@@ -1,0 +1,13 @@
+# Docker Upstart and SysVinit configuration file
+
+# Customize location of Docker binary (especially for development testing).
+#DOCKER="/usr/local/bin/docker"
+
+# Use DOCKER_OPTS to modify the daemon startup options.
+#DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"
+
+# If you need Docker to use an HTTP proxy, it can also be specified here.
+#export http_proxy="http://127.0.0.1:3128/"
+
+# This is also a handy place to tweak where Docker's temporary files go.
+#export TMPDIR="/mnt/bigdrive/docker-tmp"

--- a/templates/etc_default_docker
+++ b/templates/etc_default_docker
@@ -11,3 +11,5 @@
 
 # This is also a handy place to tweak where Docker's temporary files go.
 #export TMPDIR="/mnt/bigdrive/docker-tmp"
+
+export DOCKER_OPTS="-H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}} --storage-driver=aufs"

--- a/templates/etc_default_docker
+++ b/templates/etc_default_docker
@@ -12,4 +12,4 @@
 # This is also a handy place to tweak where Docker's temporary files go.
 #export TMPDIR="/mnt/bigdrive/docker-tmp"
 
-export DOCKER_OPTS="-H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}} --storage-driver=aufs"
+export DOCKER_OPTS="-H unix:///var/run/docker.sock -H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}} --storage-driver=aufs"


### PR DESCRIPTION
Reinstate the default UNIX socket which Docker listens on if you don't
specify different listen options. We disabled this when opening up the TCP
port for Tsuru to talk use.

This meant that `sudo docker <command>` no longer worked unless you export a
`DOCKER_HOST` environment variable or pass a `-H` argument to each command,
which was a pain.

---

Plus two supporting commits:
#### Commit default /etc/default/docker config

In preparation for rebasing our changes against it as a template. This will
make it easier to compare how we're deviated from the lxc-docker 1.7.0
defaults.
#### Convert docker config from lineinfile to template

The `lineinfile` module is undesirable because it will append a new line to
the file every time there is a change. All other lines in the default file
are comments, so we can manage the entire contents of this file, which is
more reliable.
