### PR TITLE
[#98748824] Add version pinning support for docker nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: docker-nodes
       roles:
-         - { role: docker_server, docker_port: 4567 }
+         - { role: docker_server, docker_port: 4567, docker_version: 1.7.0 }
 
 License
 -------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY_DEFAULT = 512
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "docker-server"
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY_DEFAULT
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY_DEFAULT
+  end
+
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "site.yml"
+  end
+end

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  sudo: yes
+  roles:
+    - .

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,9 +15,15 @@
 - name: Add Docker repository.
   apt_repository: repo='deb https://get.docker.io/ubuntu docker main' state=present
 
-- name: Install packages
-  apt: name="{{ item }}" update_cache=yes
-  with_items: packages
+- name: Install support packages
+  apt: name="{{ item }}"
+  with_items:
+    - wget
+
+- name: Install docker package
+  apt: name="{{ item }}{% if docker_version is defined %}={{ docker_version }}{% endif %}"
+  with_items:
+    - lxc-docker
 
 - name: Allow external access
   template: src=etc_default_docker dest=/etc/default/docker

--- a/templates/etc_default_docker
+++ b/templates/etc_default_docker
@@ -12,4 +12,4 @@
 # This is also a handy place to tweak where Docker's temporary files go.
 #export TMPDIR="/mnt/bigdrive/docker-tmp"
 
-export DOCKER_OPTS="-H unix:///var/run/docker.sock -H 0.0.0.0:{{ docker_port }} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}} --storage-driver=aufs"
+export DOCKER_OPTS="-H unix:///var/run/docker.sock -H 0.0.0.0:{{ docker_port }} {% if docker_registry_host is defined %} --insecure-registry={{docker_registry_host}}:{{docker_registry_port}} {% endif %}  --storage-driver=aufs"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,2 @@
 ---
 # vars file for docker_server
-
-packages:
-  - wget
-  - lxc-docker


### PR DESCRIPTION
[Pin the versions of components that we use](https://www.pivotaltracker.com/story/show/98748824)

**What**

To prevent breaking changes of components (e.g. Tsuru API, MongoDB, etc) causing the platform to break we should pin or build to a particular version, this will ensure a consistent build.

**How this PR should be reviewed**

This PR should be reviewed in the context of the following narative:
- I would to add vagrant support to this `ansible role` so I can develop and test it locally
- I would like to make the `docker registry` options optional because I do not have a docker registry available to me in this `vagrant basebox`
- I would like to be able to pin the installation of `lxc-docker` to a specific version
- I am consistently hitting an error that prevents docker from starting cleanly so I would like to fix this
- I would like to let people know how to use this updated `ansible role`

**How to test this PR**

A vagrant box has been provided for testing, in order to use it simply:

```
vagrant up
```

The site.yml can be updated with the relevant variables to test the new functionally e.g. `docker_version`, `docker_registry_host` and `docker_registry_port`.

**Who should review this PR**
- Anyone in the universe can review this PR but only someone on the core team should merge it (except moi!).
