### PR TITLE
[#98748824] Fix docker version support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,9 +21,9 @@
     - wget
 
 - name: Install docker package
-  apt: name="{{ item }}{% if docker_version is defined %}={{ docker_version }}{% endif %}"
+  apt: name="{{ item }}"
   with_items:
-    - lxc-docker
+    - "{% if docker_version is defined %}lxc-docker-{{ docker_version }}{% else %}lxc-docker{% endif %}"
 
 - name: Allow external access
   template: src=etc_default_docker dest=/etc/default/docker


### PR DESCRIPTION
**What**

Docker uses meta packages

**Problem**

Docker uses a meta package delivery method to encourage you to use the latest version of docker. What they do is name their packages by appending the version name to it with a hyphen rather than a version. The metapackage `lxc-docker` always points to the latest version.

To work around this I've refactored the code to make it handle the hyphen and be more extensible so you can mix and match it when using `with_items` e.g.

```
- name: Install support packages
  apt: name="{{ item }}"
  with_items:
    - foo
    - "{% if bar_version is defined %}bar={{ bar_version }}{% else %}bar{% endif %}
    - "{% if qux_version is defined %}qux-{{ qux_version }}{% else %}qux{% endif %}
```

**How to review this PR**

This PR should be reviewed in the context of the following narative:
- I want to fix my disasterous oversight

**How to test this PR**

A vagrant box has been provided for testing, in order to use it simply:

```
vagrant up
```

The site.yml can be updated with the relevant variables to test the new functionally e.g. `docker_version`, `docker_registry_host` and `docker_registry_port`.

**Who should review this PR**
- Any man, woman or honey badger (as long as it isn't anywhere near me) can review this PR, but let the honey badger do it, it's safer.
